### PR TITLE
Added NULL check when creating the message format using Spring 5

### DIFF
--- a/src/main/java/org/synyx/messagesource/InitializableMessageSource.java
+++ b/src/main/java/org/synyx/messagesource/InitializableMessageSource.java
@@ -100,7 +100,8 @@ public class InitializableMessageSource extends AbstractMessageSource implements
 
             for (String code : codeToMessage.keySet()) {
                 try {
-                    addMessage(basename, locale, code, createMessageFormat(codeToMessage.get(code), locale));
+                    String message = codeToMessage.get(code);
+                    addMessage(basename, locale, code, createMessageFormat(message != null ? message : "", locale));
                 } catch (RuntimeException e) {
                     throw new MessageInitializationException(String.format(
                             "Error processing Message code=%s locale=%s basename=%s, %s", code, locale, basename,


### PR DESCRIPTION
When using Spring 5 in your application a NPE might occur when the message passed to `createMessageFormat()` has a NULL value. 

There is no null-check in the method in the Spring Framework.